### PR TITLE
Add support for setting SSL verify modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ set :graphite_url, "your/graphite/event/url"
 require "graphite-notify/capistrano"
 ```
 
+It is possible to set ssl verify modes with `graphite_ssl_verify` variable:
+
+```
+set :graphite_ssl_verify, OpenSSL::SSL::VERIFY_PEER
+```
+
 ## Requirements
 
 graphite: http://readthedocs.org/docs/graphite

--- a/lib/graphite-notify/capistrano.rb
+++ b/lib/graphite-notify/capistrano.rb
@@ -23,6 +23,7 @@ module Capistrano
             uri = URI(graphite_url)
             http = Net::HTTP.new(uri.host, uri.port)
             http.use_ssl = true if uri.scheme == 'https'
+            http.verify_mode = graphite_ssl_verify if respond_to?(:graphite_ssl_verify)
             begin
               http.start  do |h|
                 if respond_to?(:stage)


### PR DESCRIPTION
Sometimes it feasible to disable SSL certificate checking, for example when the graphite instance is running behind firewall and you are using self-signed certificate.

This pull request adds a support to set verify modes to `Net::HTTP`. This is done by setting `graphite_ssl_verify` variable, and takes same parameters than `Net:HTTP#verify_mode` takes.

```
set :graphite_ssl_verify, OpenSSL::SSL::VERIFY_NONE
```

I added the happy case (`OpenSSL::SSL:VERIFY_PEER`) to README for not encouraging users to use the less secure option.
